### PR TITLE
Update setup scripts for network multicast and package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ bash ./script/setup_host.sh
 bash ./script/setup_network.sh 2
 
 # If you are using multiple physical machines, Run this instead:
-bash ./script/setup_optional_cross_machine_network.sh 2
+bash ./script/setup_optional_cross_machine_network.sh <num_vms> <br_ip_suffix>
+# <num_vms>: number of VMs to create on this host
+# <br_ip_suffix>: unique host identifier (1-254), used for bridge IP 192.168.100.<br_ip_suffix>
+# Example: 
+# create 1 VM on host 1
+bash ./script/setup_optional_cross_machine_network.sh 1 1
+# create 1 VM on host 2
+bash ./script/setup_optional_cross_machine_network.sh 1 2
 
 mkdir build
 cd build

--- a/script/setup_host.sh
+++ b/script/setup_host.sh
@@ -2,22 +2,22 @@
 set -x
 set -e
 
-git submodule add https://github.com/CXLMemUring/qemu lib/qemu
-git submodule add https://github.com/CXLMemUring/tigon workloads/tigon
+git submodule add https://github.com/CXLMemUring/qemu lib/qemu || true
+git submodule add https://github.com/CXLMemUring/tigon workloads/tigon || true
 
-sudo apt update && sudo apt install llvm-dev clang libbpf-dev libclang-dev python3-pip libcxxopts-dev libboost-dev nvidia-cuda-dev libfmt-dev libspdlog-dev librdmacm-dev
-pip install tomli
-pip install gdown
-sudo apt-get install libglib2.0-dev libgcrypt20-dev zlib1g-dev \
+sudo apt update && sudo apt install -y llvm-dev clang libbpf-dev libclang-dev python3-pip libcxxopts-dev libboost-dev nvidia-cuda-dev libfmt-dev libspdlog-dev librdmacm-dev
+python3 -m pip install --break-system-packages tomli
+python3 -m pip install --break-system-packages gdown
+sudo apt-get install -y libglib2.0-dev libgcrypt20-dev zlib1g-dev \
     autoconf automake libtool bison flex libpixman-1-dev bc \
     make ninja-build libncurses-dev libelf-dev libssl-dev debootstrap \
     libcap-ng-dev libattr1-dev libslirp-dev libslirp0 libpmem-dev
 
 sudo apt update
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt install -y software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt update
-sudo apt install gcc-13 g++-13
+sudo apt install -y gcc-13 g++-13
 
 mkdir temp && cd temp
 wget https://github.com/Kitware/CMake/releases/download/v4.2.3/cmake-4.2.3.tar.gz


### PR DESCRIPTION
- Enhanced cleanup process for tap devices and added a route replacement for multicast.
- Modified argument check in setup_optional_cross_machine_network.sh to require two arguments.
- Updated package installation commands to use the `-y` flag for automatic confirmation.
- Changed pip installation commands to use `python3 -m pip` with `--break-system-packages` to avoid conflicts.
