### PR TITLE
Add STREAM MPI workload

### DIFF
--- a/workloads/stream/README.md
+++ b/workloads/stream/README.md
@@ -1,0 +1,45 @@
+# STREAM
+
+[STREAM](https://www.cs.virginia.edu/stream/) measures sustained memory bandwidth. The MPI variant is required so the CXL shim (`libmpi_cxl_shim.so`) can intercept MPI calls and route memory operations through the DAX device.
+
+## Build
+
+```bash
+wget https://www.cs.virginia.edu/stream/FTP/Code/stream.c
+mpicc -O3 -fopenmp -DSTREAM_ARRAY_SIZE=1000000  -o stream_mpi_small  stream.c
+mpicc -O3 -fopenmp -DSTREAM_ARRAY_SIZE=10000000 -o stream_mpi_medium stream.c
+mpicc -O3 -fopenmp -DSTREAM_ARRAY_SIZE=80000000 -o stream_mpi_large  stream.c
+
+scp stream_mpi_small stream_mpi_medium stream_mpi_large root@node0:~/
+scp stream_mpi_small stream_mpi_medium stream_mpi_large root@node1:~/
+```
+
+## Run
+
+Create a hostfile on node0:
+
+```bash
+printf "node0 slots=1\nnode1 slots=1\n" > ~/hostfile
+```
+
+Run with CXL:
+
+```bash
+export CXL_DAX_PATH="/dev/dax0.0"
+export CXL_DAX_RESET=1
+export CXL_SHIM_VERBOSE=1
+export LD_PRELOAD=/root/libmpi_cxl_shim.so
+
+mpirun --allow-run-as-root --hostfile ~/hostfile --wdir /root \
+    -x CXL_DAX_PATH -x CXL_DAX_RESET -x CXL_SHIM_VERBOSE -x LD_PRELOAD \
+    /root/stream_mpi_large
+```
+
+Baseline (no CXL):
+
+```bash
+unset LD_PRELOAD
+mpirun --allow-run-as-root --hostfile ~/hostfile --wdir /root /root/stream_mpi_large
+```
+
+`--wdir /root` is required — the shim loads `liba.so` from the working directory. `-x` flags are required to forward env vars to remote ranks. If the shim misbehaves, reboot all nodes.

--- a/workloads/stream/run_stream_cxl.sh
+++ b/workloads/stream/run_stream_cxl.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# STREAM MPI benchmark with and without CXL shim.
+# Run from node0. Requires ~/hostfile with node0/node1 slots=1.
+
+export CXL_DAX_PATH="/dev/dax0.0"
+export CXL_DAX_RESET=1
+export CXL_SHIM_VERBOSE=1
+export LD_PRELOAD=/root/libmpi_cxl_shim.so
+
+for size in small medium large; do
+    echo "=== ${size} with CXL ==="
+    mpirun --allow-run-as-root --hostfile ~/hostfile --wdir /root \
+        -x CXL_DAX_PATH -x CXL_DAX_RESET -x CXL_SHIM_VERBOSE -x LD_PRELOAD \
+        /root/stream_mpi_${size}
+done
+
+unset LD_PRELOAD
+
+for size in small medium large; do
+    echo "=== ${size} baseline ==="
+    mpirun --allow-run-as-root --hostfile ~/hostfile --wdir /root \
+        /root/stream_mpi_${size}
+done


### PR DESCRIPTION
Add STREAM MPI benchmark under workloads/stream/.

Includes run script and README with build and run instructions.
Uses the MPI variant of STREAM with the CXL shim to measure memory
bandwidth across instances with and without CXL memory.